### PR TITLE
fix import bug introduced when adding testing

### DIFF
--- a/src/taskMgmt/getTaskDictionary.js
+++ b/src/taskMgmt/getTaskDictionary.js
@@ -1,4 +1,4 @@
-import { getTaskMap } from './getTaskMap';
+import { getTaskMap } from './getTaskMap.js';
 
 export const getTaskDictionary = async () => {
   const files = await getTaskMap();

--- a/src/taskMgmt/getTaskMap.js
+++ b/src/taskMgmt/getTaskMap.js
@@ -3,5 +3,7 @@ import { promises as fs } from 'fs';
 export const getTaskMap = async () => {
   const files = await fs.readdir('src/tasks');
   // NOTE: restrict to .js files for now
-  return files.filter((file) => file.endsWith('.js')).map((file) => file.substring(0, file.length - '.js'.length));
+  return files
+    .filter((file) => file.endsWith('.js') && !file.endsWith('.test.js'))
+    .map((file) => file.substring(0, file.length - '.js'.length));
 };

--- a/src/taskMgmt/getTaskMap.test.js
+++ b/src/taskMgmt/getTaskMap.test.js
@@ -18,7 +18,7 @@ describe('getTaskMap', () => {
   });
   beforeEach(() => {
     jest.resetAllMocks();
-    dirfiles = ['someTask.js', 'anotherTask.js', 'asubdir', 'someotherfile.txt'];
+    dirfiles = ['someTask.js', 'anotherTask.js', 'anotherTask.test.js', 'asubdir', 'someotherfile.txt'];
     fs.readdir.mockResolvedValue(dirfiles);
   });
 


### PR DESCRIPTION
Note that due to the way jest runs, node guesses the extension of ES imports (thus hiding this bug). The primary task runner does not.